### PR TITLE
Security: add top-level permissions block to CI workflow

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

Adds top-level \`permissions: contents: read\` to \`moodle-plugin-ci.yml\`, scoping the \`GITHUB_TOKEN\` to least privilege.

Resolves CodeQL finding \`actions/missing-workflow-permissions\` at \`.github/workflows/moodle-plugin-ci.yml:11\`.

## Test plan

- [x] Moodle Plugin CI workflow runs on this PR (verifies the change doesn't break the matrix tests)

Tracked under navigatr-app/navigatr-app-infrastructure#117.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to GitHub Actions workflow permissions; it may only affect the CI run if a step implicitly relied on broader `GITHUB_TOKEN` write access.
> 
> **Overview**
> Adds a top-level `permissions: contents: read` block to `.github/workflows/moodle-plugin-ci.yml`, scoping the workflow’s `GITHUB_TOKEN` to least privilege.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917d268f2a4cdcf1d78b0d58655a7d1441695ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->