### PR TITLE
Docs: document the same-repo branch contribution model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,16 @@
 
 ---
 
+## Contribution model - same-repo branch (no fork)
+
+This repo uses the **same-repo branch model**, not a fork. `origin` is the org repo (`navigatr-app/moodle-local_navigatr`), and the default branch `develop` is protected (PR plus at least one non-author review).
+
+- Work on a branch off `develop` and push it to `origin`. Omid works on a long-lived `omid` branch; agents (Connie) use short-lived feature branches.
+- Open the PR against `develop`. Same-repo branch PRs run the full check suite (CodeQL, the Cursor Security Agent, and CI); fork PRs get a read-only token and no secrets so they skip those, which is why this repo uses branches.
+- Never push `develop` directly, and do not merge your own PR (a non-author approves).
+
+---
+
 ## Key Architecture
 
 ### Badge Issuance Flow


### PR DESCRIPTION
## What
Document the same-repo branch contribution model in `CLAUDE.md`.

## Why
This repo has moved from the fork model to same-repo branches (`origin` = the org repo; work on a branch, PR to `develop`) so PRs run the full security suite (CodeQL + Cursor Security Agent), which fork PRs skip. The pipeline skills (`ship`/`implement`/`developer-mod`) defer the branch-vs-fork choice to each repo's `CLAUDE.md`, so this note is what makes them push to `origin` and PR to `develop` instead of assuming a fork.

## Change
Docs-only. Adds (auth: corrects) a "Contribution model" note. No code or behaviour change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration impact.
> 
> **Overview**
> Adds a **Contribution model** section to `CLAUDE.md` so contributors and automation (e.g. pipeline skills) know this repo uses **same-repo branches**, not forks.
> 
> The note states that `origin` is `navigatr-app/moodle-local_navigatr`, `develop` is protected (PR + non-author review), work happens on branches pushed to `origin`, and PRs target `develop` so CodeQL, the Cursor Security Agent, and CI run with full credentials—unlike fork PRs. It also records branch conventions (long-lived `omid` vs short-lived agent branches) and rules: no direct pushes to `develop`, no self-merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c6674d6953288f04bac55ed33970682c8e4c944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->