### PR TITLE
ci: auto-assign new PRs to omufeed

### DIFF
--- a/.github/workflows/assign-prs.yml
+++ b/.github/workflows/assign-prs.yml
@@ -1,0 +1,24 @@
+name: Assign new PRs to Omid
+
+# Auto-assigns every newly opened PR (any author, including fork PRs) to @omufeed
+# so Omid gets one "Assigned to me" view + a notification across all repos.
+# Uses pull_request_target so the base-repo token has write access and the run
+# is driven by THIS file on the default branch (a fork PR cannot alter it). No
+# checkout of PR code, so there is no untrusted-code execution risk.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign omufeed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR_URL" --add-assignee omufeed


### PR DESCRIPTION
Adds .github/workflows/assign-prs.yml so every newly opened PR (any author, including fork PRs) is auto-assigned to @omufeed, giving Omid one Assigned-to-me view plus a notification across all repos. Uses pull_request_target with NO checkout of PR code, so there is no untrusted-code risk. Part of an org-wide rollout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with scoped PR write permission and no execution of fork-supplied code; main caveat is pull_request_target token power if the workflow were later expanded unsafely.
> 
> **Overview**
> Adds **`.github/workflows/assign-prs.yml`**, a GitHub Actions workflow that assigns **@omufeed** whenever a PR is **opened** or **reopened**, including PRs from forks.
> 
> The job runs on **`pull_request_target`** with **`pull-requests: write`** and uses **`gh pr edit`** with **`GITHUB_TOKEN`**—no checkout of PR branch code, so only the default-branch workflow definition runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba7db8e4866a8ebf755b325eeab69b5236fed747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->